### PR TITLE
RUSI_GRPC_ENDPOINT overrides RUSI_GRPC_PORT

### DIFF
--- a/packages/message-bus/README.md
+++ b/packages/message-bus/README.md
@@ -78,6 +78,8 @@ const [topic, event] = await msgBus.sendCommandAndReceiveEvent(
 Messaging__TopicPrefix="deprecated_please_use_Messaging__Env"
 Messaging__Env="messaging_env"
 Messaging__Source="your_service_name"
+Messaging__Transport="nats_or_rusi"
+
 NATS_URL="your_nats_url"
 NATS_CLUSTER="your_nats_cluster"
 NATS_CLIENT_ID="your_nats_client_id"
@@ -89,5 +91,15 @@ NATS_PUB_SUB_MaxInflight="100"
 NATS_PUB_SUB_AckWait="5000"
 NATS_RPC_MaxInflight="1"
 NATS_RPC_AckWait="5000"
+
+RUSI_GRPC_ENDPOINT="localhost:50003"
+RUSI_GRPC_PORT="50003"
+RUSI_PUB_SUB_NAME="natsstreaming-pubsub"
+RUSI_STREAM_PROCESSOR_MaxConcurrentMessages="1"
+RUSI_STREAM_PROCESSOR_AckWaitTime="5000"
+RUSI_PUB_SUB_MaxConcurrentMessages="100"
+RUSI_PUB_SUB_AckWaitTime="5000"
+RUSI_RPC_MaxConcurrentMessages="1"
+RUSI_RPC_AckWaitTime="5000"
 
 

--- a/packages/message-bus/src/transport/rusi/index.js
+++ b/packages/message-bus/src/transport/rusi/index.js
@@ -9,6 +9,7 @@ const { SubscriptionOptions } = require('../../subscriptionOptions')
 const EventEmitter = require('events')
 
 const {
+  RUSI_GRPC_ENDPOINT,
   RUSI_GRPC_PORT,
   RUSI_STREAM_PROCESSOR_MaxConcurrentMessages,
   RUSI_STREAM_PROCESSOR_AckWaitTime,
@@ -47,7 +48,7 @@ async function _connect() {
         .v1
 
     let c = new rusi_proto.Rusi(
-      'localhost:' + (RUSI_GRPC_PORT || 50003),
+      RUSI_GRPC_ENDPOINT || 'localhost:' + (RUSI_GRPC_PORT || 50003),
       grpc.credentials.createInsecure(),
     )
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
- added RUSI_GRPC_ENDPOINT env that overrides RUSI_GRPC_PORT env needed for debugging scenario when running daemon in debug and nodebb microservice in docker