### PR TITLE
added _method validation

### DIFF
--- a/packages/knex-filters/README.md
+++ b/packages/knex-filters/README.md
@@ -9,6 +9,8 @@ npm install @totalsoft/knex-filters
 ## philosophy
 With knex-filters you can register some hooks for some or any of your tables, that will be called when specific DDL statements occur: select, insert, update, delete.
 
+> ⚠ Because of the nature of `knex.raw(...)` no filter will apply on these statements.
+
 ## filter
 A filter is a function that receives a table and returns the hooks
 ```javascript

--- a/packages/knex-filters/src/__tests__/filter.tests.js
+++ b/packages/knex-filters/src/__tests__/filter.tests.js
@@ -579,4 +579,25 @@ describe('filter tests', () => {
       expect.anything(),
     )
   })
+
+  test('raw does not break the filter', async () => {
+    //arrange
+    var knexInstance = knex({
+      client: 'mssql',
+    })
+    mockDb.mock(knexInstance)
+
+    const hooks = {
+      onSelect: jest.fn(),
+    }
+    const filter = jest.fn(() => hooks)
+    registerFilter(filter, knexInstance)
+
+    //act
+    await knexInstance.raw("select 'test'")
+
+    //assert
+    expect(filter).not.toHaveBeenCalled()
+    expect(hooks.onSelect).not.toHaveBeenCalled()
+  })
 })

--- a/packages/knex-filters/src/queryBuilder.js
+++ b/packages/knex-filters/src/queryBuilder.js
@@ -96,6 +96,7 @@ function applyOnDeleteFilter(filter, queryBuilder) {
 }
 
 function applyFilter(filter, queryBuilder) {
+  if (!queryBuilder?._method) return
   switch (queryBuilder._method) {
     case 'insert':
       applyOnInsertFilter(filter, queryBuilder)

--- a/packages/knex-filters/src/queryBuilder.js
+++ b/packages/knex-filters/src/queryBuilder.js
@@ -96,7 +96,7 @@ function applyOnDeleteFilter(filter, queryBuilder) {
 }
 
 function applyFilter(filter, queryBuilder) {
-  if (!queryBuilder?._method) return
+  if (!queryBuilder?._method) return // skipping raw queries
   switch (queryBuilder._method) {
     case 'insert':
       applyOnInsertFilter(filter, queryBuilder)


### PR DESCRIPTION
on `knex.raw(...)` the query builder type is no longer a `Builder` with `_method` and other props used by the filter. in this scenario we get a `Raw` object with little information and most of the used properties as `undefined`.
this breaks the filter, making it impossible to register 2 filters that want to use the `buildTableHasColumnPredicate` from this library.
or if you use a filter, you can no longer use `knex.raw`